### PR TITLE
Added middleware component as per discussions

### DIFF
--- a/examples/example.cpp
+++ b/examples/example.cpp
@@ -10,9 +10,35 @@ class ExampleLogHandler : public crow::ILogHandler {
         }
 };
 
+class ExampleMiddleware : public crow::IMiddleware {
+    public:
+        const char* tag_;
+        ExampleMiddleware(const char* tag) : tag_(tag) {}
+        void before_handle(const crow::request& req, crow::response& res)
+        {
+            CROW_LOG_DEBUG << "Middleware " << tag_ << " : before handle";
+
+            // Uncomment next line to observe the middleware stack change
+            //res.end("Middleware ended the response early.");
+        }
+        void after_handle(const crow::request& req, crow::response& res)
+        {
+            CROW_LOG_DEBUG << "Middleware " << tag_ << " : after handle";
+        }
+};
+
 int main()
 {
     crow::Crow app;
+
+    app.use(new ExampleMiddleware("A"));
+
+    app.use([](const crow::request& req, crow::response& res){
+        CROW_LOG_DEBUG << "Middleware B : before handle";
+    },
+    [](const crow::request& req, crow::response& res){
+        CROW_LOG_DEBUG << "Middleware B : after handle";
+    });
 
     CROW_ROUTE(app, "/")
         .name("hello")

--- a/include/http_response.h
+++ b/include/http_response.h
@@ -59,11 +59,11 @@ namespace crow
         {
             if (!completed_)
             {
-                completed_ = true;
                 if (complete_request_handler_)
                 {
                     complete_request_handler_();
                 }
+                completed_ = true;
             }
         }
 
@@ -71,6 +71,11 @@ namespace crow
         {
             body += body_part;
             end();
+        }
+
+        bool is_completed() 
+        {
+            return completed_;
         }
 
         bool is_alive()

--- a/include/middleware.h
+++ b/include/middleware.h
@@ -1,0 +1,83 @@
+#pragma once
+#include "http_request.h"
+#include "http_response.h"
+
+namespace crow
+{
+
+class IMiddleware {
+	public:
+		virtual void before_handle(const request& req, response& res) = 0;
+		virtual void after_handle(const request& req, response& res) = 0;
+};
+
+class Middleware {
+
+private:
+	//
+	typedef std::vector<IMiddleware*> HandlersList;
+	HandlersList handlers;
+
+public:
+	//
+	void use(IMiddleware* middlewareObj)
+	{
+		handlers.push_back(middlewareObj);
+	}
+
+	int count()
+	{
+		return (int)handlers.size(); 
+	}
+
+	unsigned int processBeforeHandlers(const request& req, response& res) 
+	{
+		unsigned int depth = 0;
+		for(auto i : handlers)
+		{
+			++depth;
+			i->before_handle(req, res);
+			if(res.is_completed())
+			{
+				break;
+			}		
+		}
+		return depth;
+	}	
+
+	void processAfterHandlers(const request& req, response& res, unsigned int depth = 0)
+	{
+		auto i = handlers.rbegin();
+		if (depth > 0){
+			i += (handlers.size() - depth);
+		}
+		for(; i != handlers.rend(); ++i)
+		{
+			(*i)->after_handle(req, res);
+		}
+	}	
+};
+
+/////////////
+
+typedef std::function<void(const request& req, response& res)> MiddlewareHandlerFunc;
+
+class LambdaMiddlewareHandler : public IMiddleware {
+		
+	private:
+		MiddlewareHandlerFunc m_before;
+		MiddlewareHandlerFunc m_after;
+	public:
+		LambdaMiddlewareHandler(MiddlewareHandlerFunc before, MiddlewareHandlerFunc after) : m_before(before), m_after(after) {}
+		void before_handle(const request& req, response& res) {
+			if(m_before != nullptr)
+				m_before(req, res);
+		}
+		void after_handle(const request& req, response& res) {
+			if(m_after != nullptr)
+				m_after(req, res);
+		}
+};
+
+
+}


### PR DESCRIPTION
Changes from the last PR:
- Depth is tracked as middlewares wind and unwind, so any middlewares that end() a response prevent middlewares further down the chain getting either their 'before' or 'after' called.
- Middleware handlers are now handled as `IMiddleware*`
- Restructured `middleware.h` to be more in line with the structure of other crow source files
- Fixed a bug in http_response.h in which the `completed_ = true` was being reverted by a call to `res.clear()` inside the completed response handler.
