### PR TITLE
Fixed a bug in which response objects believed they were completed when they weren't.

### DIFF
--- a/include/http_response.h
+++ b/include/http_response.h
@@ -84,11 +84,12 @@ namespace crow
         {
             if (!completed_)
             {
+                completed_ = true;
+                
                 if (complete_request_handler_)
                 {
                     complete_request_handler_();
                 }
-                completed_ = true;
             }
         }
 


### PR DESCRIPTION
I noticed, when doing quick requests to the same endpoint, that the body was only delivered _every other_ request. I verified this by first tracking the request in the browser network tools, then by adding size checking to the response object. I narrowed it down to a condition that was being skipped here:

https://github.com/ipkn/crow/blob/master/include/http_connection.h#L204

I have tracked this down to a logic error in which the response `clear()` is called by the `complete_request_handler_` callback, only to have the `completed_` boolean set back to `true` once the callback returns.

The fix moves the assignment to before the completion callback. The problem is no longer observable, but the flow is still questionable, where the boolean is assigned and then immediately cleared.
