### PR TITLE
`CROW_ROUTE` macro for  the `CROW_MSVC_WORKAROUND` case

### DIFF
--- a/include/crow.h
+++ b/include/crow.h
@@ -16,7 +16,12 @@
 #include "http_request.h"
 #include "http_server.h"
 
+
+#ifdef CROW_MSVC_WORKAROUND
+#define CROW_ROUTE(app, url) app.route_dynamic(url)
+#else
 #define CROW_ROUTE(app, url) app.route<crow::black_magic::get_parameter_tag(url)>(url)
+#endif
 
 namespace crow
 {


### PR DESCRIPTION
Hi,

there's an example that is only used for Visual Studio. I think, the duplication could be removed by switching the `CROW_ROUTE` macro to the `route_dynamic` method when `CROW_MSVC_WORKAROUND` is defined. While the compile time checks will not work, the code wouldn't need to be rewritten for VS.

By the way, compiling on VS2015 seems to work (see [repo](https://github.com/d-led/crow_example))