### PR TITLE
Added inline to get_type_str

### DIFF
--- a/include/json.h
+++ b/include/json.h
@@ -82,7 +82,7 @@ namespace crow
             Object,
         };
 
-        const char* get_type_str(type t) {
+        inline const char* get_type_str(type t) {
             switch(t){
                 case type::Number: return "Number";
                 case type::False: return "False";


### PR DESCRIPTION
Visual Studio 2013 compiler was complaining to me about multiply defined symbols until I made this change.

I didn't get the same error with the examples though. 