### PR TITLE
Add JSON u() for type casting to an uint64_t, Fix all compiler warning (with gcc 4.9.2)

### DIFF
--- a/amalgamate/crow_all.h
+++ b/amalgamate/crow_all.h
@@ -291,7 +291,7 @@ namespace crow
                     case type::String:
                         return boost::lexical_cast<int64_t>(start_, end_-start_);
                     default:
-                        throw std::runtime_error(strcat("expected number, got: ", get_type_str(t())));
+                        throw std::runtime_error(std::string("expected number, got: ") + get_type_str(t()));
                 }
 #endif
                 return boost::lexical_cast<int64_t>(start_, end_-start_);
@@ -310,8 +310,6 @@ namespace crow
 #endif
                 return boost::lexical_cast<uint64_t>(start_, end_-start_);
             }
-
-
 
             double d() const
             {

--- a/include/common.h
+++ b/include/common.h
@@ -122,5 +122,5 @@ constexpr crow::HTTPMethod operator "" _method(const char* str, size_t len)
         crow::black_magic::is_equ_p(str, "CONNECT", 7) ? crow::HTTPMethod::CONNECT :
         crow::black_magic::is_equ_p(str, "TRACE", 5) ? crow::HTTPMethod::TRACE :
         throw std::runtime_error("invalid http method");
-};
+}
 #endif

--- a/include/crow.h
+++ b/include/crow.h
@@ -195,5 +195,4 @@ namespace crow
     template <typename ... Middlewares>
     using App = Crow<Middlewares...>;
     using SimpleApp = Crow<>;
-};
-
+}

--- a/include/http_response.h
+++ b/include/http_response.h
@@ -49,7 +49,7 @@ namespace crow
         {
             json_mode();
         }
-        response(int code, const json::wvalue& json_value) : code(code), body(json::dump(json_value))
+        response(int code, const json::wvalue& json_value) : body(json::dump(json_value)), code(code)
         {
             json_mode();
         }

--- a/include/json.h
+++ b/include/json.h
@@ -291,7 +291,7 @@ namespace crow
                     case type::String:
                         return boost::lexical_cast<int64_t>(start_, end_-start_);
                     default:
-                        throw std::runtime_error(strcat("expected number, got: ", get_type_str(t())));
+                        throw std::runtime_error(std::string("expected number, got: ") + get_type_str(t()));
                 }
 #endif
                 return boost::lexical_cast<int64_t>(start_, end_-start_);

--- a/include/json.h
+++ b/include/json.h
@@ -82,7 +82,7 @@ namespace crow
             Object,
         };
 
-        const char* get_type_str(type t) {
+        inline const char* get_type_str(type t) {
             switch(t){
                 case type::Number: return "Number";
                 case type::False: return "False";
@@ -92,7 +92,7 @@ namespace crow
                 case type::Object: return "Object";
                 default: return "Unknown";
             }
-        };
+        }
 
         class rvalue;
         rvalue load(const char* data, size_t size);
@@ -262,6 +262,11 @@ namespace crow
                 return i();
             }
 
+            explicit operator uint64_t() const
+            {
+                return u();
+            }
+
             explicit operator int() const
             {
                 return (int)i();
@@ -290,6 +295,20 @@ namespace crow
                 }
 #endif
                 return boost::lexical_cast<int64_t>(start_, end_-start_);
+            }
+
+            uint64_t u() const
+            {
+#ifndef CROW_JSON_NO_ERROR_CHECK
+                switch (t()) {
+                    case type::Number:
+                    case type::String:
+                        return boost::lexical_cast<uint64_t>(start_, end_-start_);
+                    default:
+                        throw std::runtime_error(std::string("expected number, got: ") + get_type_str(t()));
+                }
+#endif
+                return boost::lexical_cast<uint64_t>(start_, end_-start_);
             }
 
             double d() const

--- a/include/utility.h
+++ b/include/utility.h
@@ -129,7 +129,7 @@ template <> \
 struct parameter_tag<t> \
 { \
     static const int value = i; \
-};
+}
         CROW_INTERNAL_PARAMETER_TAG(int, 1);
         CROW_INTERNAL_PARAMETER_TAG(char, 1);
         CROW_INTERNAL_PARAMETER_TAG(short, 1);

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -515,6 +515,10 @@ TEST(json_read)
     ASSERT_EQUAL(false, z["bools"][1].b());
     ASSERT_EQUAL(1.2, z["doubles"][0].d());
     ASSERT_EQUAL(-3.4, z["doubles"][1].d());
+
+    std::string s3 = R"({"uint64": 18446744073709551615})";
+    auto z1 = json::load(s3);
+    ASSERT_EQUAL(18446744073709551615ull, z1["uint64"].u());
 }
 
 TEST(json_read_real)


### PR DESCRIPTION
Add JSON u() for type casting to an uint64_t
Add explicit operator uint64_t()
Remove all compiler warning. (done with gcc 4.9.2)
