### PR TITLE
Implement zlib based compression middleware

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ addons:
       - g++-4.8
       - libboost1.55-all-dev
       - python-pip
+      - zlib1g-dev
 
 install:
   - if [ "$PUSH_COVERAGE" == "ON" ]; then pip install --user git+git://github.com/eddyxu/cpp-coveralls.git; fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,11 @@ ${PROJECT_SOURCE_DIR}/include
 include_directories("${PROJECT_INCLUDE_DIR}")
 include_directories("${PROJECT_SOURCE_DIR}")
  
+find_package(ZLIB)
+if(ZLIB_FOUND)
+    include_directories( ${ZLIB_INCLUDE_DIR} )
+endif()
+ 
 #add_subdirectory(src)
 add_subdirectory(examples)
 if (MSVC)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -20,6 +20,14 @@ add_executable(example example.cpp)
 target_link_libraries(example ${Boost_LIBRARIES})
 target_link_libraries(example ${CMAKE_THREAD_LIBS_INIT})
 
+if (ZLIB_FOUND)
+    add_definitions(-DCROW_ENABLE_COMPRESSION)
+    add_executable(example_compression example_compression.cpp)
+    target_link_libraries(example_compression ${Boost_LIBRARIES})
+    target_link_libraries(example_compression ${CMAKE_THREAD_LIBS_INIT})
+    target_link_libraries(example_compression ${ZLIB_LIBRARIES})
+endif()
+
 if (Tcmalloc_FOUND)
 target_link_libraries(example ${Tcmalloc_LIBRARIES})
 endif(Tcmalloc_FOUND)
@@ -28,6 +36,7 @@ add_executable(example_with_all example_with_all.cpp)
 #target_link_libraries(example crow)
 target_link_libraries(example_with_all ${Boost_LIBRARIES})
 target_link_libraries(example_with_all ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(example_with_all ${ZLIB_LIBRARIES})
 
 add_custom_command(OUTPUT example_test.py
         COMMAND ${CMAKE_COMMAND} -E

--- a/examples/example_compression.cpp
+++ b/examples/example_compression.cpp
@@ -1,0 +1,29 @@
+#include "crow.h"
+#include "middleware_compression.h"
+
+int main()
+{
+    crow::App<crow::CompressionDeflate> app;
+    //crow::App<crow::CompressionGzip> app;
+
+    CROW_ROUTE(app, "/hello")
+    ([&](const crow::request& req){
+        app.get_context<crow::CompressionDeflate>(req).compress = false;
+        //app.get_context<crow::CompressionGzip>(req).compress = false;
+
+        return "Hello World! This is uncompressed!";
+    });
+
+    CROW_ROUTE(app, "/hello_compressed")
+    ([](){
+        return "Hello World! This is compressed by default!";
+    });
+
+    // ignore all log
+    crow::logger::setLogLevel(crow::LogLevel::DEBUG);
+    //crow::logger::setHandler(std::make_shared<ExampleLogHandler>());
+
+    app.port(18080)
+        .multithreaded()
+        .run();
+}

--- a/include/middleware_compression.h
+++ b/include/middleware_compression.h
@@ -1,0 +1,137 @@
+#pragma once
+
+#ifdef CROW_ENABLE_COMPRESSION
+
+#include "http_request.h"
+#include "http_response.h"
+
+#include <zlib.h>
+
+// http://zlib.net/manual.html
+
+namespace crow
+{
+    namespace compression
+    {
+        // Values used in the 'windowBits' parameter for deflateInit2.
+        enum algorithm
+        {
+            // 15 is the default value for deflate
+            DEFLATE = 15,
+            // windowBits can also be greater than 15 for optional gzip encoding. 
+            // Add 16 to windowBits to write a simple gzip header and trailer around the compressed data instead of a zlib wrapper.
+            GZIP = 15|16,
+        };
+
+        std::string compress_string(std::string const & str, algorithm algo)
+        {
+            std::string compressed_str;
+            z_stream stream{};
+            // Initialize with the default values
+            if (::deflateInit2(&stream, Z_DEFAULT_COMPRESSION, Z_DEFLATED, algo, 8, Z_DEFAULT_STRATEGY) == Z_OK)
+            {      
+                char buffer[8192];
+
+                stream.avail_in = str.size();
+                // zlib does not take a const pointer. The data is not altered.
+                stream.next_in = const_cast<Bytef *>(reinterpret_cast<const Bytef *>(str.c_str()));
+
+                int code = Z_OK;
+                do
+                {
+                    stream.avail_out = sizeof(buffer);
+                    stream.next_out = reinterpret_cast<Bytef *>(&buffer[0]);
+
+                    code = ::deflate(&stream, Z_FINISH);
+                    // Successful and non-fatal error code returned by deflate when used with Z_FINISH flush
+                    if (code == Z_OK || code == Z_STREAM_END)
+                    {
+                        std::copy(&buffer[0], &buffer[sizeof(buffer) - stream.avail_out], std::back_inserter(compressed_str));
+                    }
+
+                } while (code == Z_OK);
+
+                if (code != Z_STREAM_END)
+                    compressed_str.clear();
+
+                ::deflateEnd(&stream);
+            }
+
+            return compressed_str;
+        }
+    }
+
+    // Middleware for deflate algorithm
+    struct CompressionDeflate
+    {
+        struct context
+        {
+            // Compress by default
+            bool compress = true;
+        };
+
+        void before_handle(crow::request & request, crow::response & response, context & ctx)
+        {
+        }
+
+        void after_handle(crow::request & request, crow::response & response, context & ctx)
+        {
+            // Only compress if told to
+            if (ctx.compress == false)
+                return;
+
+            std::string compressed_body = compression::compress_string(response.body, compression::algorithm::DEFLATE);
+
+            // If compression went fine, replace the body; otherwise, leave it as is
+            if (compressed_body.empty() == false)
+            {
+                response.body = std::move(compressed_body);
+                // Attach the appropriate header so the client knows how to handle the data
+                response.add_header("Content-Encoding", "deflate");
+            }
+            else
+            {
+                // Warn and do nothing
+                CROW_LOG_WARNING << "Unable to compress request for " << request.url;
+            }
+        }
+    };
+
+    // Middleware for gzip algorithm
+    struct CompressionGzip
+    {
+        struct context
+        {
+            // Compress by default
+            bool compress = true;
+        };
+
+        void before_handle(crow::request & request, crow::response & response, context & ctx)
+        {
+        }
+
+        void after_handle(crow::request & request, crow::response & response, context & ctx)
+        {
+            // Only compress if told to
+            if (ctx.compress == false)
+                return;
+
+            std::string compressed_body = compression::compress_string(response.body, compression::algorithm::GZIP);
+
+            // If compression went fine, replace the body; otherwise, leave it as is
+            if (compressed_body.empty() == false)
+            {
+                response.body = std::move(compressed_body);
+                // Attach the appropriate header so the client knows how to handle the data
+                response.add_header("Content-Encoding", "gzip");
+            }
+            else
+            {
+                // Warn and do nothing
+                CROW_LOG_WARNING << "Unable to compress request for " << request.url;
+            }
+        }
+    };
+}
+
+#endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,10 +6,13 @@ set(TEST_SRCS
 unittest.cpp
 )
 
+add_definitions(-DCROW_ENABLE_COMPRESSION)
+
 add_executable(unittest ${TEST_SRCS})
 #target_link_libraries(unittest crow)
 target_link_libraries(unittest ${Boost_LIBRARIES})
 target_link_libraries(unittest ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(unittest ${ZLIB_LIBRARIES})
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
 # using Clang


### PR DESCRIPTION
Summary of changes:

Added crow::CompressionDeflate middleware
Added crow::CompressionGzip middleware
Added CROW_ENABLE_COMPRESSION definition
Added deflate and gzip tests
Added example

By default, compression is enabled for every route. If someone uses the compression middleware, then odds are they want compression anyways. An example showing how to disable compression for a route is provided in [example_compression.cpp](https://github.com/pierobot/crow/blob/b78c91098a99047fd24d0b8baf0bc231df47846a/examples/example_compression.cpp)