### PR TITLE
Fixed crow::json::detail::r_string move operator

### DIFF
--- a/include/json.h
+++ b/include/json.h
@@ -131,6 +131,8 @@ namespace crow
                     s_ = r.s_;
                     e_ = r.e_;
                     owned_ = r.owned_;
+                    if (r.owned_)
+                        r.owned_ = 0;
                     return *this;
                 }
 


### PR DESCRIPTION
Hi guys,
it is small fix to r_string helper class of json part.
```
#include <iostream>
#include "json.h"

crow::json::rvalue get() {
	std::string str = "{\"key\":\"value\"}";
	return crow::json::load(str);
}

int main() {
	auto res = get();
	std::cout << res << std::endl;
	return 0;
}
```
If you run it you will get assert (I got it in Visual Studio 2015 U3).