### PR TITLE
Fixed missing static keyword for non-template functions

### DIFF
--- a/include/utility.h
+++ b/include/utility.h
@@ -500,7 +500,7 @@ template <typename F, typename Set>
             using arg = typename std::tuple_element<i, std::tuple<Args...>>::type;
         };
 
-        std::string base64encode(const char* data, size_t size, const char* key = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/")
+        static std::string base64encode(const char* data, size_t size, const char* key = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/")
         {
             std::string ret;
             ret.resize((size+2) / 3 * 4);
@@ -536,7 +536,7 @@ template <typename F, typename Set>
             return ret;
         }
 
-        std::string base64encode_urlsafe(const char* data, size_t size)
+        static std::string base64encode_urlsafe(const char* data, size_t size)
         {
             return base64encode(data, size, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_");
         }


### PR DESCRIPTION
Hi again :),
seems that "static" keyword has been missed for base64 functions.
Without "static" we get linker-time error about "already defined functions".