### PR TITLE
MS VS2015 compilation fix.

### DIFF
--- a/include/crow/json.h
+++ b/include/crow/json.h
@@ -1377,7 +1377,12 @@ namespace crow
                 case type::Number: 
                     {
                         char outbuf[128];
+#ifdef _MSC_VER
+                        sprintf_s(outbuf, 128, "%g", v.d);
+#else
                         sprintf(outbuf, "%g", v.d);
+#endif
+
                         out += outbuf;
                     }
                     break;

--- a/include/crow/query_string.h
+++ b/include/crow/query_string.h
@@ -222,8 +222,12 @@ inline char * qs_scanvalue(const char * key, const char * qs, char * val, size_t
     {
         qs++;
         i = strcspn(qs, "&=#");
-        strncpy(val, qs, (val_len-1)<(i+1) ? (val_len-1) : (i+1));
-        qs_decode(val);
+#ifdef _MSC_VER
+        strncpy_s(val, val_len, qs, (val_len - 1)<(i + 1) ? (val_len - 1) : (i + 1));
+#else
+        strncpy(val, qs, (val_len - 1)<(i + 1) ? (val_len - 1) : (i + 1));
+#endif
+		qs_decode(val);
     }
     else
     {


### PR DESCRIPTION
It’s better to use native Win32 `strncpy_s`, `sprintf_s` to avoid compilation errors when using MS C++.
