### PR TITLE
Show the number of threads used in the startup message

### DIFF
--- a/include/crow/http_server.h
+++ b/include/crow/http_server.h
@@ -141,7 +141,8 @@ namespace crow
                         });
             }
 
-            CROW_LOG_INFO << server_name_ << " server is running, local port " << port_;
+            CROW_LOG_INFO << server_name_ << " server is running on port " << port_
+                          << " using " << concurrency_ << " threads";
 
             signals_.async_wait(
                 [&](const boost::system::error_code& /*error*/, int /*signal_number*/){


### PR DESCRIPTION
This can be useful, especially when using the default hardware concurrency, to
see how many threads does the server actually use in the logs.