### PR TITLE
Use atomic type for connection count shared between threads

### DIFF
--- a/include/crow/http_connection.h
+++ b/include/crow/http_connection.h
@@ -176,7 +176,7 @@ namespace crow
     }
 
 #ifdef CROW_ENABLE_DEBUG
-    static int connectionCount;
+    static std::atomic<int> connectionCount;
 #endif
     template <typename Adaptor, typename Handler, typename ... Middlewares>
     class Connection


### PR DESCRIPTION
Even if this variable is only used in debug mode, it's still bad to have data
races on it, as it was the case (and reported by thread sanitizer) before.