### PR TITLE
Add compatibility with conan.io

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ build
 
 .directory
 crow_all.h
+
+# conan.io
+build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 2.8)
 project (crow_all)
+
+include(build/conanbuildinfo.cmake)
+conan_basic_setup()
+
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
 find_package(Tcmalloc)
 find_package(Threads)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,10 @@
 cmake_minimum_required(VERSION 2.8)
 project (crow_all)
 
+if(EXISTS "${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
+endif()
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
 find_package(Tcmalloc)
@@ -28,13 +30,13 @@ endif()
 
 include_directories( ${Boost_INCLUDE_DIR} )
 
-set(PROJECT_INCLUDE_DIR 
+set(PROJECT_INCLUDE_DIR
 ${PROJECT_SOURCE_DIR}/include
 )
 
 include_directories("${PROJECT_INCLUDE_DIR}")
 include_directories("${PROJECT_SOURCE_DIR}")
- 
+
 #add_subdirectory(src)
 add_subdirectory(examples)
 if (MSVC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8)
 project (crow_all)
 
-include(build/conanbuildinfo.cmake)
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")

--- a/conanfile.py
+++ b/conanfile.py
@@ -14,7 +14,7 @@ class CrowConan(ConanFile):
 
     def build(self):
         cmake = CMake(self.settings)
-	self.run('cmake %s %s' % (self.conanfile_directory, cmake.command_line))
+	# self.run('cmake %s %s' % (self.conanfile_directory, cmake.command_line))
         self.run("cmake . %s" % cmake.build_config)
 	self.run("make")
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,5 +1,6 @@
 from conans import ConanFile, CMake
 
+
 class CrowConan(ConanFile):
     name = "Crow"
     version = "0.1"
@@ -10,6 +11,7 @@ class CrowConan(ConanFile):
 
     requires = (("Boost/1.60.0@lasote/stable"),
                 ("OpenSSL/1.0.2i@lasote/stable"))
+
     # No exports necessary
 
     def source(self):
@@ -18,9 +20,10 @@ class CrowConan(ConanFile):
 
     def build(self):
         cmake = CMake(self.settings)
-	    self.run('cmake %s/crow %s' % (self.conanfile_directory, cmake.command_line))
-	    self.run("cmake --build . %s" % cmake.build_config)
-	    self.run("make")
+        self.run('cmake %s/crow %s' % (self.conanfile_directory, cmake.command_line))
+        self.run("cmake --build . %s" % cmake.build_config)
+        self.run("make")
 
-    def package(self):
-        self.copy("*.h", dst="include", src="amalgamate")
+
+def package(self):
+    self.copy("*.h", dst="include", src="amalgamate")

--- a/conanfile.py
+++ b/conanfile.py
@@ -7,6 +7,9 @@ class CrowConan(ConanFile):
     license = "see https://github.com/ipkn/crow/blob/master/LICENSE"
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake"
+
+    requires = (("Boost/1.60.0@lasote/stable"),
+                ("OpenSSL/1.0.2i@lasote/stable"))
     # No exports necessary
 
     def source(self):

--- a/conanfile.py
+++ b/conanfile.py
@@ -15,7 +15,7 @@ class CrowConan(ConanFile):
     def build(self):
         cmake = CMake(self.settings)
 	self.run('cmake %s/crow %s' % (self.conanfile_directory, cmake.command_line))
-        self.run("cmake . %s" % cmake.build_config)
+	self.run("cmake --build . %s" % cmake.build_config)
 	self.run("make")
 
     def package(self):

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,5 +1,4 @@
 from conans import ConanFile, CMake
-import shutil
 
 class CrowConan(ConanFile):
     name = "Crow"
@@ -12,11 +11,10 @@ class CrowConan(ConanFile):
     def source(self):
         # this will create a hello subfolder, take it into account
         self.run("git clone https://github.com/javierjeronimo/crow.git")
-	shutil.move("crow/*", ".")
 
     def build(self):
         cmake = CMake(self.settings)
-	# self.run('cmake %s %s' % (self.conanfile_directory, cmake.command_line))
+	self.run('cmake %s/crow %s' % (self.conanfile_directory, cmake.command_line))
         self.run("cmake . %s" % cmake.build_config)
 	self.run("make")
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -24,6 +24,5 @@ class CrowConan(ConanFile):
         self.run("cmake --build . %s" % cmake.build_config)
         self.run("make")
 
-
-def package(self):
-    self.copy("*.h", dst="include", src="amalgamate")
+    def package(self):
+        self.copy("*.h", dst="include", src="amalgamate")

--- a/conanfile.py
+++ b/conanfile.py
@@ -5,7 +5,6 @@ class CrowConan(ConanFile):
     version = "0.1"
     url = "https://github.com/javierjeronimo/crow"
     license = "see https://github.com/ipkn/crow/blob/master/LICENSE"
-    settings = "os", "compiler", "build_type", "arch"
     generators = "cmake"
 
     requires = (("Boost/1.60.0@lasote/stable"),

--- a/conanfile.py
+++ b/conanfile.py
@@ -6,6 +6,7 @@ class CrowConan(ConanFile):
     url = "https://github.com/javierjeronimo/crow"
     license = "see https://github.com/ipkn/crow/blob/master/LICENSE"
     settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
     # No exports necessary
 
     def source(self):

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,23 @@
+from conans import ConanFile, CMake
+
+class CrowConan(ConanFile):
+    name = "Crow"
+    version = "0.1"
+    settings = "os", "compiler", "build_type", "arch"
+    # No exports necessary
+
+    def source(self):
+        # this will create a hello subfolder, take it into account
+        self.run("git clone https://github.com/javierjeronimo/crow.git")
+
+    def build(self):
+        cmake = CMake(self.settings)
+        self.run("cmake . %s" % cmake.build_config)
+	self.run("make")
+
+    def package(self):
+        self.copy("*.h", dst="include", src="amalgamate")
+
+    def package_info(self):
+        self.cpp_info.libs = ["crow"]
+

--- a/conanfile.py
+++ b/conanfile.py
@@ -6,6 +6,7 @@ class CrowConan(ConanFile):
     url = "https://github.com/javierjeronimo/crow"
     license = "see https://github.com/ipkn/crow/blob/master/LICENSE"
     generators = "cmake"
+    settings = "os", "compiler", "build_type", "arch"
 
     requires = (("Boost/1.60.0@lasote/stable"),
                 ("OpenSSL/1.0.2i@lasote/stable"))
@@ -17,13 +18,9 @@ class CrowConan(ConanFile):
 
     def build(self):
         cmake = CMake(self.settings)
-	self.run('cmake %s/crow %s' % (self.conanfile_directory, cmake.command_line))
-	self.run("cmake --build . %s" % cmake.build_config)
-	self.run("make")
+	    self.run('cmake %s/crow %s' % (self.conanfile_directory, cmake.command_line))
+	    self.run("cmake --build . %s" % cmake.build_config)
+	    self.run("make")
 
     def package(self):
         self.copy("*.h", dst="include", src="amalgamate")
-
-    def package_info(self):
-        self.cpp_info.libs = ["crow"]
-

--- a/conanfile.py
+++ b/conanfile.py
@@ -3,6 +3,8 @@ from conans import ConanFile, CMake
 class CrowConan(ConanFile):
     name = "Crow"
     version = "0.1"
+    url = "https://github.com/javierjeronimo/crow"
+    license = "see https://github.com/ipkn/crow/blob/master/LICENSE"
     settings = "os", "compiler", "build_type", "arch"
     # No exports necessary
 
@@ -12,6 +14,7 @@ class CrowConan(ConanFile):
 
     def build(self):
         cmake = CMake(self.settings)
+	self.run('cmake %s %s' % (self.conanfile_directory, cmake.command_line))
         self.run("cmake . %s" % cmake.build_config)
 	self.run("make")
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,4 +1,5 @@
 from conans import ConanFile, CMake
+import shutil
 
 class CrowConan(ConanFile):
     name = "Crow"
@@ -11,6 +12,7 @@ class CrowConan(ConanFile):
     def source(self):
         # this will create a hello subfolder, take it into account
         self.run("git clone https://github.com/javierjeronimo/crow.git")
+	shutil.move("crow/*", ".")
 
     def build(self):
         cmake = CMake(self.settings)

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,7 +1,0 @@
-[requires]
-Boost/1.60.0@lasote/stable
-OpenSSL/1.0.2i@lasote/stable
-
-[generators]
-cmake
-

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,0 +1,7 @@
+[requires]
+Boost/1.60.0@lasote/stable
+OpenSSL/1.0.2i@lasote/stable
+
+[generators]
+cmake
+


### PR DESCRIPTION
# Description
Hi, this is just to allow using crow as a conan.io dependency.
* You may change conanfile.py::CrowConan::url to your github repo URL.
* You may review dependencies in conanfile.py::CrowConan: Boost 1.60.0, OpenSSL 1.0.2i

# To test:

In MacOS
```bash
brew install cmake conan

git clone... && cd crow && git checkout...

mkdir build && cd build
conan install .. # This will download and compile dependencies: Boost & OpenSSL
cmake ..
make

cd ..
conan export yournamehere # To user's local conan.io packages repository
```
From that point, amalgamated library works fine in another project if it is added as a conan.io dependency:
```
[requires]
Boost/1.60.0@lasote/stable
Crow/0.1@yournamehere/testing

[generators]
cmake
```

It may be compatible with cmake alone, but not tested.

There are other issues related to tests (executables are located in "build/bin" directory. I think this is related to cmake+conan:
```bash
$ make test
Running tests...
Test project /Users/javier/ClionProjects/crow_original/build
    Start 1: crow_test
Could not find executable /Users/javier/ClionProjects/crow_original/build/tests/unittest
Looked in the following places:
/Users/javier/ClionProjects/crow_original/build/tests/unittest
/Users/javier/ClionProjects/crow_original/build/tests/unittest
/Users/javier/ClionProjects/crow_original/build/tests/Release/unittest
/Users/javier/ClionProjects/crow_original/build/tests/Release/unittest
/Users/javier/ClionProjects/crow_original/build/tests/Debug/unittest
/Users/javier/ClionProjects/crow_original/build/tests/Debug/unittest
/Users/javier/ClionProjects/crow_original/build/tests/MinSizeRel/unittest
/Users/javier/ClionProjects/crow_original/build/tests/MinSizeRel/unittest
/Users/javier/ClionProjects/crow_original/build/tests/RelWithDebInfo/unittest
/Users/javier/ClionProjects/crow_original/build/tests/RelWithDebInfo/unittest
/Users/javier/ClionProjects/crow_original/build/tests/Deployment/unittest
/Users/javier/ClionProjects/crow_original/build/tests/Deployment/unittest
/Users/javier/ClionProjects/crow_original/build/tests/Development/unittest
/Users/javier/ClionProjects/crow_original/build/tests/Development/unittest
Users/javier/ClionProjects/crow_original/build/tests/unittest
Users/javier/ClionProjects/crow_original/build/tests/unittest
Users/javier/ClionProjects/crow_original/build/tests/Release/unittest
Users/javier/ClionProjects/crow_original/build/tests/Release/unittest
Users/javier/ClionProjects/crow_original/build/tests/Debug/unittest
Users/javier/ClionProjects/crow_original/build/tests/Debug/unittest
Users/javier/ClionProjects/crow_original/build/tests/MinSizeRel/unittest
Users/javier/ClionProjects/crow_original/build/tests/MinSizeRel/unittest
Users/javier/ClionProjects/crow_original/build/tests/RelWithDebInfo/unittest
Users/javier/ClionProjects/crow_original/build/tests/RelWithDebInfo/unittest
Users/javier/ClionProjects/crow_original/build/tests/Deployment/unittest
Users/javier/ClionProjects/crow_original/build/tests/Deployment/unittest
Users/javier/ClionProjects/crow_original/build/tests/Development/unittest
Users/javier/ClionProjects/crow_original/build/tests/Development/unittest
Unable to find executable: /Users/javier/ClionProjects/crow_original/build/tests/unittest
1/2 Test #1: crow_test ........................***Not Run   0.00 sec
    Start 2: template_test
2/2 Test #2: template_test ....................***Failed    0.06 sec

0% tests passed, 2 tests failed out of 2

Total Test time (real) =   0.06 sec

The following tests FAILED:
          1 - crow_test (Not Run)
          2 - template_test (Failed)
Errors while running CTest
make: *** [test] Error 8
```