### PR TITLE
Fixed a problem that warning appeared in c ++ 11

### DIFF
--- a/include/crow/routing.h
+++ b/include/crow/routing.h
@@ -456,10 +456,16 @@ namespace crow
             static_assert(!std::is_same<void, decltype(f(std::declval<Args>()...))>::value, 
                 "Handler function cannot have void return type; valid return types: string, int, crow::resposne, crow::json::wvalue");
 
-                handler_ = [f = std::move(f)](const request&, response& res, Args ... args){
+            handler_ = (
+#ifdef CROW_CAN_USE_CPP14
+                [f = std::move(f)]
+#else
+                [f]
+#endif
+                (const request&, response& res, Args ... args){
                     res = response(f(args...));
                     res.end();
-                };
+                });
         }
 
         template <typename Func>
@@ -475,10 +481,16 @@ namespace crow
             static_assert(!std::is_same<void, decltype(f(std::declval<crow::request>(), std::declval<Args>()...))>::value, 
                 "Handler function cannot have void return type; valid return types: string, int, crow::resposne, crow::json::wvalue");
 
-                handler_ = [f = std::move(f)](const crow::request& req, crow::response& res, Args ... args){
+            handler_ = (
+#ifdef CROW_CAN_USE_CPP14
+                [f = std::move(f)]
+#else
+                [f]
+#endif
+                (const crow::request& req, crow::response& res, Args ... args){
                     res = response(f(req, args...));
                     res.end();
-                };
+                });
         }
 
         template <typename Func>


### PR DESCRIPTION
I Built it on Mac OS X.

```
$ g++ --version
Configured with: --prefix=/Applications/Xcode.app/Contents/Developer/usr --with-gxx-include-dir=/usr/include/c++/4.2.1
Apple LLVM version 7.0.0 (clang-700.0.72)
Target: x86_64-apple-darwin14.5.0
Thread model: posix
```

```
$ g++ helloworld.cpp -std=c++11 -I ../include/
In file included from helloworld.cpp:1:
In file included from ../include/crow.h:19:
../include/crow/routing.h:459:29: warning: initialized lambda captures are a C++14 extension [-Wc++14-extensions]
                handler_ = [f = std::move(f)](const request&, response& res, Args ... args){
                            ^
../include/crow/routing.h:478:29: warning: initialized lambda captures are a C++14 extension [-Wc++14-extensions]
                handler_ = [f = std::move(f)](const crow::request& req, crow::response& res, Args ... args){
                            ^
2 warnings generated.
```

I modified it with reference to a similar code on routing.h.