### PR TITLE
Fixed bug in r_string

### DIFF
--- a/include/crow/json.h
+++ b/include/crow/json.h
@@ -168,9 +168,10 @@ namespace crow
                     return os;
                 }
             private:
-                void force(char* s, uint32_t /*length*/)
+                void force(char* s, uint32_t length)
                 {
                     s_ = s;
+                    e_ = s_ + length;
                     owned_ = 1;
                 }
                 friend rvalue crow::json::load(const char* data, size_t size);


### PR DESCRIPTION
The end-of-string pointer was not updated in the force member function

This could lead to undefined behaviour in the std::string conversion
operator, when using the iterator interface (begin() / end()), and the size()
member function.