### PR TITLE
Fixed bug in json::rvalue copy constructor

### DIFF
--- a/include/crow/json.h
+++ b/include/crow/json.h
@@ -238,9 +238,9 @@ namespace crow
                 start_ = r.start_;
                 end_ = r.end_;
                 key_ = r.key_;
-                copy_l(r);
                 t_ = r.t_;
                 option_ = r.option_;
+                copy_l(r);
                 return *this;
             }
             rvalue& operator = (rvalue&& r) noexcept


### PR DESCRIPTION
Don't call copy_l before all other members are set. This lead to undefined behaviour during copy.