### PR TITLE
Fixed warning in websocket.h: right shift count >= width of type

### DIFF
--- a/include/crow/websocket.h
+++ b/include/crow/websocket.h
@@ -152,7 +152,7 @@ namespace crow
                     else
                     {
                         buf[1] += 127;
-                        *(uint64_t*)(buf+2) = ((1==htonl(1)) ? (uint64_t)size : ((uint64_t)htonl((size) & 0xFFFFFFFF) << 32) | htonl((size) >> 32));
+                        *reinterpret_cast<uint64_t*>(buf+2) = ((1==htonl(1)) ? static_cast<uint64_t>(size) : (static_cast<uint64_t>(htonl((size) & 0xFFFFFFFF)) << 32) | htonl(static_cast<uint64_t>(size) >> 32));
                         return {buf, buf+10};
                     }
                 }


### PR DESCRIPTION
Fixed by static_cast-ing values from 32-bit values to 64-bit values.