### PR TITLE
Using std::gmtime (Instead of gmtime_r and gmtime_s)

### DIFF
--- a/include/crow/http_server.h
+++ b/include/crow/http_server.h
@@ -80,15 +80,8 @@ namespace crow
                             auto update_date_str = [&]
                             {
                                 auto last_time_t = time(0);
-                                tm my_tm;
-
-#ifdef _MSC_VER
-                                gmtime_s(&my_tm, &last_time_t);
-#else
-                                gmtime_r(&last_time_t, &my_tm);
-#endif
                                 date_str.resize(100);
-                                size_t date_str_sz = strftime(&date_str[0], 99, "%a, %d %b %Y %H:%M:%S GMT", &my_tm);
+                                size_t date_str_sz = strftime(&date_str[0], 99, "%a, %d %b %Y %H:%M:%S GMT", gmtime(&last_time_t));
                                 date_str.resize(date_str_sz);
                             };
                             update_date_str();

--- a/include/crow/logging.h
+++ b/include/crow/logging.h
@@ -49,15 +49,7 @@ namespace crow
                 char date[32];
                 time_t t = time(0);
 
-                tm my_tm;
-
-#ifdef _MSC_VER
-                gmtime_s(&my_tm, &t);
-#else
-                gmtime_r(&t, &my_tm);
-#endif
-
-                size_t sz = strftime(date, sizeof(date), "%Y-%m-%d %H:%M:%S", &my_tm);
+                size_t sz = strftime(date, sizeof(date), "%Y-%m-%d %H:%M:%S", gmtime(&t));
                 return std::string(date, date+sz);
             }
 


### PR DESCRIPTION
I'm using crow on MinGW, which does not build. Would it be possible to use std::gmtime as a more portable equivalent?

(This is my very first Github pull request. Let me know if I am failing any rules of etiquette. Thank you very much for Crow.)