### PR TITLE
Use os.path.join and os.path.sep instead of "/"

### DIFF
--- a/amalgamate/merge_all.py
+++ b/amalgamate/merge_all.py
@@ -5,14 +5,18 @@ import re
 from collections import defaultdict
 import sys
 
-header_path = "../include"
+header_path = pt.join(pt.dirname(__file__), "..", "include")
 if len(sys.argv) > 1:
     header_path = sys.argv[1]
 
 OUTPUT = 'crow_all.h'
 re_depends = re.compile('^#include "(.*)"', re.MULTILINE)
-headers = [x.rsplit('/', 1)[-1] for x in glob(pt.join(header_path, '*.h*'))]
-headers += ['crow/' + x.rsplit('/', 1)[-1] for x in glob(pt.join(header_path, 'crow/*.h*'))]
+headers = [ x.rsplit(pt.sep, 1)[-1]
+            for x in glob(pt.join(header_path, '*.h*')) ]
+
+headers += [pt.join('crow', x.rsplit(pt.sep, 1)[-1])
+            for x in glob(pt.join(header_path, pt.join('crow', '*.h*')))]
+
 print(headers)
 edges = defaultdict(list)
 for header in headers:


### PR DESCRIPTION
Using "/" literal does not work on Windows/MinGW.

Also use `__file__` to be able to run from different directories, such as `python amalgamate/merge_all.py`