### PR TITLE
Fix connection close bug when response write over 5 seconds

### DIFF
--- a/include/crow/http_connection.h
+++ b/include/crow/http_connection.h
@@ -557,9 +557,17 @@ namespace crow
             {
                 if (!adaptor_.is_open())
                 {
-                    return;
+                    return true;
                 }
+				
+				if(this->is_writing)
+				{
+					CROW_LOG_DEBUG << this << " timer called functor but didn't close connection in writing";
+					return false;					
+				}
                 adaptor_.close();
+				
+				return true;
             });
             CROW_LOG_DEBUG << this << " timer added: " << timer_cancel_key_.first << ' ' << timer_cancel_key_.second;
         }


### PR DESCRIPTION
Fix connection close in tick time(5 seconds default)  even if remaining to write response data.

When writing response to client over 5 seconds, connection will close by timer. so if big response data or weak network condition make reset connection before received all response.