### PR TITLE
Fix for MSVC

### DIFF
--- a/examples/example_vs.cpp
+++ b/examples/example_vs.cpp
@@ -93,7 +93,7 @@ int main()
 
     // more json example
     app.route_dynamic("/add_json")
-        .methods(crow::HTTPMethod::POST)
+        .methods(crow::HTTPMethod::Post)
     ([](const crow::request& req){
         auto x = crow::json::load(req.body);
         if (!x)
@@ -122,7 +122,7 @@ int main()
     });    
 
     // ignore all log
-    crow::logger::setLogLevel(crow::LogLevel::DEBUG);
+    crow::logger::setLogLevel(crow::LogLevel::Debug);
     //crow::logger::setHandler(std::make_shared<ExampleLogHandler>());
 
     app.port(18080)


### PR DESCRIPTION
The example doesn't compile in MSVC:

```
1>\crow\examples\example_vs.cpp(96): error C2838: 'POST': illegal qualified name in member declaration
1>\crow\examples\example_vs.cpp(96): error C2065: 'POST': undeclared identifier
1>\crow\examples\example_vs.cpp(125): error C2838: 'DEBUG': illegal qualified name in member declaration
1>\crow\examples\example_vs.cpp(125): error C2065: 'DEBUG': undeclared identifier
```

This PR fixes it.