### PR TITLE
fix:  boot 1.70

### DIFF
--- a/include/crow/socket_adaptors.h
+++ b/include/crow/socket_adaptors.h
@@ -4,6 +4,11 @@
 #include <boost/asio/ssl.hpp>
 #endif
 #include "crow/settings.h"
+#if BOOST_VERSION >= 107000
+#define GET_IO_SERVICE(s) ((boost::asio::io_context&)(s).get_executor().context())
+#else
+#define GET_IO_SERVICE(s) ((s).get_io_service())
+#endif
 namespace crow
 {
     using namespace boost;
@@ -19,7 +24,7 @@ namespace crow
 
         boost::asio::io_service& get_io_service()
         {
-            return socket_.get_io_service();
+            return GET_IO_SERVICE(socket_);
         }
 
         tcp::socket& raw_socket()
@@ -96,7 +101,7 @@ namespace crow
 
         boost::asio::io_service& get_io_service()
         {
-            return raw_socket().get_io_service();
+            return GET_IO_SERVICE(raw_socket());
         }
 
         template <typename F> 


### PR DESCRIPTION
The patch fixes issue with boost 1.70: https://github.com/ipkn/crow/issues/340

Patch is based on the patch submitted to other project: https://github.com/moneroexamples/onion-monero-blockchain-explorer/commit/76a0efa8ee3ea5bb466b81d84357d2fd76920cbd