### PR TITLE
shutdown before close

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ crow_all.h
 
 # conan.io
 build/
+
+.idea
+cmake-build-debug

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ addons:
       - g++-4.9
       - g++-5
       - clang-3.6
-      - libboost1.55-all-dev
+      - libboost-all-dev
       - python-pip
 
 install:

--- a/include/crow/http_connection.h
+++ b/include/crow/http_connection.h
@@ -480,6 +480,7 @@ namespace crow
                     {
                         cancel_deadline_timer();
                         parser_.done();
+                        adaptor_.shutdown_recv();
                         adaptor_.close();
                         is_reading = false;
                         CROW_LOG_DEBUG << this << " from read(1)";
@@ -520,6 +521,7 @@ namespace crow
                     {
                         if (close_connection_)
                         {
+                            adaptor_.shutdown_send();
                             adaptor_.close();
                             CROW_LOG_DEBUG << this << " from write(1)";
                             check_destroy();
@@ -559,6 +561,7 @@ namespace crow
                 {
                     return;
                 }
+                adaptor_.shutdown_both();
                 adaptor_.close();
             });
             CROW_LOG_DEBUG << this << " timer added: " << timer_cancel_key_.first << ' ' << timer_cancel_key_.second;

--- a/include/crow/socket_adaptors.h
+++ b/include/crow/socket_adaptors.h
@@ -48,6 +48,24 @@ namespace crow
             socket_.close(ec);
         }
 
+        void shutdown_both()
+        {
+            boost::system::error_code ec;
+            socket_.shutdown(boost::asio::socket_base::shutdown_type::shutdown_both, ec);
+        }
+
+        void shutdown_send()
+        {
+            boost::system::error_code ec;
+            socket_.shutdown(boost::asio::socket_base::shutdown_type::shutdown_send, ec);
+        }
+
+        void shutdown_recv()
+        {
+            boost::system::error_code ec;
+            socket_.shutdown(boost::asio::socket_base::shutdown_type::shutdown_receive, ec);
+        }
+
         template <typename F> 
         void start(F f)
         {

--- a/include/crow/socket_adaptors.h
+++ b/include/crow/socket_adaptors.h
@@ -112,6 +112,24 @@ namespace crow
             raw_socket().close(ec);
         }
 
+        void shutdown_both()
+        {
+            boost::system::error_code ec;
+            raw_socket().shutdown(boost::asio::socket_base::shutdown_type::shutdown_both, ec);
+        }
+
+        void shutdown_send()
+        {
+            boost::system::error_code ec;
+            raw_socket().shutdown(boost::asio::socket_base::shutdown_type::shutdown_send, ec);
+        }
+
+        void shutdown_recv()
+        {
+            boost::system::error_code ec;
+            raw_socket().shutdown(boost::asio::socket_base::shutdown_type::shutdown_receive, ec);
+        }
+
         boost::asio::io_service& get_io_service()
         {
             return raw_socket().get_io_service();


### PR DESCRIPTION
Tick value is 5 second by default, timer will expire if interval betweent two request is larger than 5 seconds.

Server will `close` the socket if timer is expired,  but Client still send HTTP request to the socket.
the length of data using`async_read_some`  from the socket  is **0**, HTTP request from client skipped, and callback will not invoke!

It's ok if `shutdown` before `close`, so Client will receive *FIN* and `close` the socket, then start 3-way handshake.
 
Have tested using **tcpdump** and **Wireshark**.

*boost/asio/basic_socket.hpp*  also recommend to `shutdown` before `close`, reference below:
> @note For portable behaviour with respect to graceful closure of a connected socket, call shutdown() before closing the socket.