### PR TITLE
patch boost1.70

### DIFF
--- a/boost170.patch
+++ b/boost170.patch
@@ -1,0 +1,34 @@
+diff --git a/include/crow/socket_adaptors.h b/include/crow/socket_adaptors.h
+index eebd50f9..06d4baf4 100644
+--- a/include/crow/socket_adaptors.h
++++ b/include/crow/socket_adaptors.h
+@@ -4,6 +4,11 @@
+ #include <boost/asio/ssl.hpp>
+ #endif
+ #include "crow/settings.h"
++#if BOOST_VERSION >= 107000
++#define GET_IO_SERVICE(s) ((boost::asio::io_context&)(s).get_executor().context())
++#else
++#define GET_IO_SERVICE(s) ((s).get_io_service())
++#endif
+ namespace crow
+ {
+     using namespace boost;
+@@ -19,7 +24,7 @@ namespace crow
+ 
+         boost::asio::io_service& get_io_service()
+         {
+-            return socket_.get_io_service();
++            return GET_IO_SERVICE(socket_);
+         }
+ 
+         tcp::socket& raw_socket()
+@@ -94,7 +99,7 @@ namespace crow
+ 
+         boost::asio::io_service& get_io_service()
+         {
+-            return raw_socket().get_io_service();
++            return GET_IO_SERVICE(raw_socket());
+         }
+ 
+         template <typename F> 

--- a/include/crow/socket_adaptors.h
+++ b/include/crow/socket_adaptors.h
@@ -4,6 +4,11 @@
 #include <boost/asio/ssl.hpp>
 #endif
 #include "crow/settings.h"
+#if BOOST_VERSION >= 107000
+#define GET_IO_SERVICE(s) ((boost::asio::io_context&)(s).get_executor().context())
+#else
+#define GET_IO_SERVICE(s) ((s).get_io_service())
+#endif
 namespace crow
 {
     using namespace boost;
@@ -19,7 +24,7 @@ namespace crow
 
         boost::asio::io_service& get_io_service()
         {
-            return socket_.get_io_service();
+            return GET_IO_SERVICE(socket_);
         }
 
         tcp::socket& raw_socket()
@@ -96,7 +101,7 @@ namespace crow
 
         boost::asio::io_service& get_io_service()
         {
-            return raw_socket().get_io_service();
+            return GET_IO_SERVICE(raw_socket());
         }
 
         template <typename F> 


### PR DESCRIPTION
This fixes compatibility issue with Boost >= 1.70 . Referenced from : https://github.com/moneroexamples/onion-monero-blockchain-explorer/commit/76a0efa8ee3ea5bb466b81d84357d2fd76920cbd?diff=unified